### PR TITLE
adapt to recent VILLASnode changes

### DIFF
--- a/include/dpsim-villas/InterfaceVillas.h
+++ b/include/dpsim-villas/InterfaceVillas.h
@@ -44,7 +44,7 @@ namespace DPsim {
 	protected:
 		//Villas node to send / receive data to / from
 		String mNodeConfig;
-		std::unique_ptr<node::Node> mNode;
+		node::Node* mNode;
 
 		int mQueueLength;
 		int mSampleLength;

--- a/src/InterfaceVillas.cpp
+++ b/src/InterfaceVillas.cpp
@@ -162,6 +162,8 @@ void InterfaceVillas::close() {
 	}
 
 	mNode->getFactory()->stop();
+
+	delete mNode;
 }
 
 void InterfaceVillas::readValues(bool blocking) {

--- a/src/pybind-dpsim-villas.cpp
+++ b/src/pybind-dpsim-villas.cpp
@@ -49,7 +49,7 @@ public:
 
 			auto signal = py::dict(
 				"name"_a = s->name,
-				"type"_a = node::signal_type_to_str(s->type)
+				"type"_a = node::signalTypeToString(s->type)
 			);
 
 			if (!s->unit.empty()) {


### PR DESCRIPTION
This PR updates dpsim-villas to reflect recent changes in the VILLASnode master branch, especially the switch from `NodeType` to `NodeFactory`. No changes were made to the overall function of the VillasInterface. For this to work in DPsim, one also has to update the version of VILLASnode specified in the Dockerfiles to use some updated commit / tag on the master branch.